### PR TITLE
feat(client): introduce mumble client

### DIFF
--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -1,25 +1,13 @@
 package dev.jakedoes
 
-import dev.jakedoes.mumble.SocketProvider
-import dev.jakedoes.mumble.domain.Authenticate
-import dev.jakedoes.mumble.domain.ChannelState
-import dev.jakedoes.mumble.domain.CryptSetup
-import dev.jakedoes.mumble.domain.Ping
-import dev.jakedoes.mumble.domain.TextMessage
-import dev.jakedoes.mumble.domain.Version
-import dev.jakedoes.mumble.protocol.MessageType
-import dev.jakedoes.mumble.protocol.MumbleProtocol
+import dev.jakedoes.mumble.MumbleClient
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.network.sockets.*
-import io.ktor.utils.io.*
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
-import kotlin.reflect.KClass
+import kotlinx.coroutines.runBlocking
 
 private val logger = KotlinLogging.logger { }
 
-// ./gradlew run --args "localhost 64738 mumble-client-cert.p12 mumble-server-cert.pem"
-suspend fun main(args: Array<String>) {
+// ./gradlew run --args "localhost 64738 '' mumble-client-cert.p12 mumble-server-cert.pem"
+fun main(args: Array<String>) = runBlocking {
     assert(args.size == 5) { "Expected four arguments in my array" }
     val (hostname, port, password, clientCertPath, serverCertPath) = args
 
@@ -28,63 +16,8 @@ suspend fun main(args: Array<String>) {
     - the client cert created from Mumble's 'Certificate Wizard' has no password, and no alias.
     - I used `openssl s_client -connect localhost:64738 -showcerts` to get the server-side cert
      */
-
-    val socket = SocketProvider.ssl(hostname, port.toInt(), clientCertPath, serverCertPath)
-    val writer = socket.openWriteChannel()
-    val reader = socket.openReadChannel()
-
-    connect(writer, password)
-
-    while (true) {
-        val id = ByteBuffer.wrap(reader.readByteArray(2))
-            .order(ByteOrder.BIG_ENDIAN)
-
-        val length = ByteBuffer.wrap(reader.readByteArray(4))
-            .order(ByteOrder.BIG_ENDIAN)
-
-        val payload = ByteBuffer.allocate(length.getInt(0))
-        repeat(length.getInt(0)) { payload.put(reader.readByte()) }
-
-        when (MessageType.fromId(id.short)) {
-            MessageType.TextMessage -> decode(payload.array(), TextMessage::class)
-            MessageType.ChannelState -> decode(payload.array(), ChannelState::class)
-            MessageType.CryptSetup -> decode(payload.array(), CryptSetup::class)
-            MessageType.Ping -> decode(payload.array(), Ping::class)
-
-            else -> logger.info { "Received a different message!" }
-        }
-
-        reader.awaitContent(6)
-    }
-}
-
-private inline fun <reified T : Any> decode(payload: ByteArray, clazz: KClass<T>): T {
-    logger.info { "Received a ${clazz.simpleName}!" }
-    val message: T = MumbleProtocol.decodePayload(payload, clazz)
-    logger.info { "Message: $message" }
-    return message
-}
-
-private suspend fun connect(writer: ByteWriteChannel, password: String) {
-    writer.writeByteArray(
-        MumbleProtocol.encode(
-            Version(
-                major = 1L,
-                minor = 5L,
-                os = "Linux",
-                osVersion = "Fedora KDE 42",
-                release = "1.5.0",
-            )
-        )
-    )
-    writer.flush()
-
-    writer.writeByteArray(
-        MumbleProtocol.encode(
-            Authenticate(
-                "jake-does-testing", password
-            )
-        )
-    )
-    writer.flush()
+    val client = MumbleClient.connect(hostname, port.toInt(), clientCertPath, serverCertPath)
+    client.handshake(1L, 5L, "jake-does-testing", password)
+    client.startPinging()
+    client.startReadingMessages()
 }

--- a/src/main/kotlin/mumble/MumbleClient.kt
+++ b/src/main/kotlin/mumble/MumbleClient.kt
@@ -1,0 +1,119 @@
+package dev.jakedoes.mumble
+
+import dev.jakedoes.mumble.domain.*
+import dev.jakedoes.mumble.protocol.MessageType
+import dev.jakedoes.mumble.protocol.MumbleProtocol
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.network.sockets.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.coroutines.CoroutineContext
+import kotlin.reflect.KClass
+import kotlin.time.Duration.Companion.seconds
+
+private val logger = KotlinLogging.logger { }
+
+class MumbleClient(val reader: ByteReadChannel, val writer: ByteWriteChannel, private val socket: Socket) :
+    CoroutineScope {
+    override val coroutineContext: CoroutineContext = Job() + Dispatchers.IO + CoroutineName("MumbleClientScope")
+
+    private var pingJob: Job? = null
+    private var readMessagesJob: Job? = null
+
+    companion object {
+        suspend fun connect(
+            hostname: String,
+            port: Int,
+            clientCertPath: String,
+            serverCertPath: String
+        ): MumbleClient {
+            val socket = SocketProvider.ssl(hostname, port, clientCertPath, serverCertPath)
+            return MumbleClient(socket.openReadChannel(), socket.openWriteChannel(), socket)
+        }
+    }
+
+    fun startPinging() {
+        if (pingJob?.isActive == true) {
+            logger.info { "Ping job already active." }
+            return
+        }
+        pingJob =
+            launch(CoroutineName("MumbleClient-Pinger")) { // 'launch' is available directly because MumbleClient implements CoroutineScope
+                while (isActive) { // This 'isActive' refers to the MumbleClient's coroutineContext
+                    ping()
+                    delay(15.seconds)
+                }
+                logger.info { "Ping job stopped." }
+            }
+    }
+
+    fun startReadingMessages() {
+        if (readMessagesJob?.isActive == true) {
+            logger.info { "Message reading job already active." }
+            return
+        }
+        readMessagesJob = launch(CoroutineName("MumbleClient-MessageHandler")) {
+            while (isActive) {
+                val id = ByteBuffer.wrap(reader.readByteArray(2))
+                    .order(ByteOrder.BIG_ENDIAN)
+
+                val length = ByteBuffer.wrap(reader.readByteArray(4))
+                    .order(ByteOrder.BIG_ENDIAN)
+
+                val payload = ByteBuffer.allocate(length.getInt(0))
+                repeat(length.getInt(0)) { payload.put(reader.readByte()) }
+
+                when (MessageType.fromId(id.short)) {
+                    MessageType.TextMessage -> {
+                        val receivedMessage = decode(payload.array(), TextMessage::class)
+                        writer.writeByteArray(
+                            MumbleProtocol.encode(
+                                TextMessage(message = "Hello! You said: ${receivedMessage.message}", treeId = listOf(0))
+                            )
+                        )
+                        writer.flush()
+                    }
+
+                    MessageType.ChannelState -> decode(payload.array(), ChannelState::class)
+                    MessageType.CryptSetup -> decode(payload.array(), CryptSetup::class)
+                    MessageType.Ping -> decode(payload.array(), Ping::class)
+                    MessageType.ServerSync -> decode(payload.array(), ServerSync::class)
+                    else -> logger.warn { "Unknown message type received" }
+                }
+            }
+        }
+    }
+
+    suspend fun handshake(major: Long, minor: Long, username: String, password: String) {
+        writer.writeByteArray(
+            MumbleProtocol.encode(
+                Version(
+                    major = major,
+                    minor = minor,
+                    os = "linux",
+                    osVersion = "mumblekt",
+                    release = "1.5.0",
+                )
+            )
+        )
+        writer.flush()
+
+        writer.writeByteArray(MumbleProtocol.encode(Authenticate(username, password)))
+        writer.flush()
+    }
+
+    suspend fun ping() {
+        writer.writeByteArray(MumbleProtocol.encode(Ping()))
+        writer.flush()
+        logger.info { "Sent ping!" }
+    }
+
+    private inline fun <reified T : Any> decode(payload: ByteArray, clazz: KClass<T>): T {
+        logger.info { "Received a ${clazz.simpleName}!" }
+        val message: T = MumbleProtocol.decodePayload(payload, clazz)
+        logger.info { "Message: $message" }
+        return message
+    }
+}

--- a/src/main/kotlin/mumble/domain/Ping.kt
+++ b/src/main/kotlin/mumble/domain/Ping.kt
@@ -5,4 +5,19 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
-object Ping
+class Ping {
+    override fun toString(): String {
+        return "Ping()"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+
+}

--- a/src/main/kotlin/mumble/domain/ServerSync.kt
+++ b/src/main/kotlin/mumble/domain/ServerSync.kt
@@ -1,0 +1,14 @@
+package dev.jakedoes.mumble.domain
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+data class ServerSync(
+    @ProtoNumber(1) val session: Int? = null,
+    @ProtoNumber(2) val maxBandwidth: Int? = null,
+    @ProtoNumber(3) val welcomeText: String? = null,
+    @ProtoNumber(4) val permissions: Long? = null,
+)

--- a/src/main/kotlin/mumble/protocol/MumbleProtocol.kt
+++ b/src/main/kotlin/mumble/protocol/MumbleProtocol.kt
@@ -6,6 +6,7 @@ import dev.jakedoes.mumble.domain.Authenticate
 import dev.jakedoes.mumble.domain.ChannelState
 import dev.jakedoes.mumble.domain.CryptSetup
 import dev.jakedoes.mumble.domain.Ping
+import dev.jakedoes.mumble.domain.ServerSync
 import dev.jakedoes.mumble.domain.TextMessage
 import dev.jakedoes.mumble.domain.Version
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -25,32 +26,45 @@ private fun ByteArray.toAsciiHexString() = joinToString("") {
         "{${it.toUByte().toString(16).padStart(2, '0').uppercase()}}"
 }
 
+/**
+ * The ideal way to do this would be to have a `sealed interface`, and each of the serializable data classes implement
+ * that interface. Gives us exhaustive branches, and safety, which is nice.
+ *
+ * However, if we do this, then the serialized messages out of the Protobuf encoder have the fully qualified class
+ * name as part of its message - i.e., `dev.jakedoes.mumble.protocol.TextMessage`. Whilst this is valid for the
+ * Protobuf implementation, it does not play ball with Mumble's protocol. Consequently, we have to take a bit of
+ * verbosity here.
+ */
 object MumbleProtocol {
     fun <T : Any> encode(message: T): ByteArray =
         when (message) {
             is Version -> {
-                logger.info { "Encoded a [Version], yielding the following hex: ${ProtoBuf.encodeToHexString<Version>(message)}" }
+                logger.debug { "Encoded a [Version], yielding the following hex: ${ProtoBuf.encodeToHexString<Version>(message)}" }
                 encode(MessageType.Version.id, ProtoBuf.encodeToByteArray<Version>(message))
             }
             is Authenticate -> {
-                logger.info { "Encoded a [Authenticate], yielding the following hex: ${ProtoBuf.encodeToHexString<Authenticate>(message)}" }
+                logger.debug { "Encoded a [Authenticate], yielding the following hex: ${ProtoBuf.encodeToHexString<Authenticate>(message)}" }
                 encode(MessageType.Authenticate.id, ProtoBuf.encodeToByteArray<Authenticate>(message))
             }
             is Ping -> {
-                logger.info { "Encoded a [Ping], yielding the following hex: ${ProtoBuf.encodeToHexString<Ping>(message)}" }
+                logger.debug { "Encoded a [Ping], yielding the following hex: ${ProtoBuf.encodeToHexString<Ping>(message)}" }
                 encode(MessageType.Ping.id, ProtoBuf.encodeToByteArray<Ping>(message))
             }
             is ChannelState -> {
-                logger.info { "Encoded a [ChannelState], yielding the following hex: ${ProtoBuf.encodeToHexString<ChannelState>(message)}" }
+                logger.debug { "Encoded a [ChannelState], yielding the following hex: ${ProtoBuf.encodeToHexString<ChannelState>(message)}" }
                 encode(MessageType.ChannelState.id, ProtoBuf.encodeToByteArray<ChannelState>(message))
             }
             is CryptSetup -> {
-                logger.info { "Encoded a [CryptSetup], yielding the following hex: ${ProtoBuf.encodeToHexString<CryptSetup>(message)}" }
+                logger.debug { "Encoded a [CryptSetup], yielding the following hex: ${ProtoBuf.encodeToHexString<CryptSetup>(message)}" }
                 encode(MessageType.CryptSetup.id, ProtoBuf.encodeToByteArray<CryptSetup>(message))
             }
             is TextMessage -> {
-                logger.info { "Encoded a [TextMessage], yielding the following hex: ${ProtoBuf.encodeToHexString<TextMessage>(message)}" }
+                logger.debug { "Encoded a [TextMessage], yielding the following hex: ${ProtoBuf.encodeToHexString<TextMessage>(message)}" }
                 encode(MessageType.TextMessage.id, ProtoBuf.encodeToByteArray<TextMessage>(message))
+            }
+            is ServerSync -> {
+                logger.debug { "Encoded a [ServerSync], yielding the following hex: ${ProtoBuf.encodeToHexString<ServerSync>(message)}" }
+                encode(MessageType.ServerSync.id, ProtoBuf.encodeToByteArray<ServerSync>(message))
             }
             else -> throw IllegalArgumentException("Unknown type for encoding: ${message.javaClass}")
         }
@@ -63,7 +77,7 @@ object MumbleProtocol {
             .put(payload)
             .array()
 
-        logger.info { "Sending: ${encoding.toAsciiHexString()}" }
+        logger.debug { "Sending: ${encoding.toAsciiHexString()}" }
         return encoding
     }
 
@@ -78,6 +92,7 @@ object MumbleProtocol {
             ChannelState::class -> ProtoBuf.decodeFromByteArray<ChannelState>(payload) as T
             CryptSetup::class -> ProtoBuf.decodeFromByteArray<CryptSetup>(payload) as T
             TextMessage::class -> ProtoBuf.decodeFromByteArray<TextMessage>(payload) as T
+            ServerSync::class -> ProtoBuf.decodeFromByteArray<ServerSync>(payload) as T
             else -> throw IllegalArgumentException("Unknown type for decoding: ${clazz.simpleName}")
         }
     }

--- a/src/test/kotlin/mumble/protocol/MumbleProtocolTest.kt
+++ b/src/test/kotlin/mumble/protocol/MumbleProtocolTest.kt
@@ -6,6 +6,7 @@ import dev.jakedoes.mumble.domain.Version
 import dev.jakedoes.mumble.protocol.MumbleProtocol
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 class MumbleProtocolTest {
@@ -36,7 +37,7 @@ class MumbleProtocolTest {
     @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun ping() {
-        val ping = Ping
+        val ping = Ping()
         val serialized = MumbleProtocol.encode(ping)
         val deserialized = MumbleProtocol.decode(serialized, Ping::class)
         assertEquals(ping, deserialized)


### PR DESCRIPTION
Introduces a mumble client, alongside two Kotlin Coroutines:
- one that regularly `Ping`s the server, as defined by https://github.com/mumble-voip/mumble/blob/master/docs/dev/network-protocol/establishing_connection.md#version-exchange
- one that handles the messages